### PR TITLE
Listen to 'event' from Rollup instead of 'change' to restart the Electron process

### DIFF
--- a/scripts/dev-runner.js
+++ b/scripts/dev-runner.js
@@ -78,7 +78,11 @@ async function start() {
 
   startElectron(RENDERER_URL)
 
-  mainWatcher.on('change', () => {
+  mainWatcher.on('event', (event) => {
+    if (event.code !== 'BUNDLE_END') {
+      return
+    }
+
     if (electronProcess && electronProcess.kill) {
       manualRestart = true
       process.kill(electronProcess.pid)


### PR DESCRIPTION
The original `change` event handler restarts the Electron process prematurely. The `dev-runner.js` script was already listening to the `event` event from Rollup during the initial run too.